### PR TITLE
Adding CLI interface with Typer to be able to pipe HTML files to betterhtmlchunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ By contrast, **betterhtmlchunking** preserves the **HTML DOM structure**, calcul
 
 You can even combine the two techniques if you need both **structured extraction** (via betterhtmlchunking) and **LLM-friendly text chunking** (via LangChain) for advanced tasks such as summarization, semantic search, or large-scale QA pipelines.
 
+## CLI
+
+The package ships with a small command line interface built with [Typer](https://typer.tiangolo.com/). You can pipe HTML to the tool and obtain a specific chunk as HTML:
+
+```bash
+cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 1 > chunk.html
+```
+
+By default the command reads from `stdin`, processes chunks up to a maximum length of 32,768 characters, and prints the HTML corresponding to chunk index `0` to `stdout`.
+
 ## License
 
 MIT License

--- a/betterhtmlchunking/cli.py
+++ b/betterhtmlchunking/cli.py
@@ -1,0 +1,40 @@
+import sys
+import typer
+from .main import DomRepresentation, ReprLengthComparisionBy
+
+app = typer.Typer(help="Chunk HTML documents from the command line")
+
+@app.command()
+def chunk(
+    max_length: int = typer.Option(
+        32768,
+        "--max-length",
+        "-l",
+        help="Maximum length for a region of interest",
+    ),
+    chunk_index: int = typer.Option(
+        0,
+        "--chunk-index",
+        "-c",
+        help="Index of the chunk to output",
+    ),
+    by_text: bool = typer.Option(
+        False,
+        "--text",
+        help="Compare length using text instead of HTML",
+    ),
+):
+    """Read HTML from stdin and output the selected chunk as HTML."""
+    html_input = sys.stdin.read()
+    compare = ReprLengthComparisionBy.TEXT_LENGTH if by_text else ReprLengthComparisionBy.HTML_LENGTH
+    dom = DomRepresentation(
+        MAX_NODE_REPR_LENGTH=max_length,
+        website_code=html_input,
+        repr_length_compared_by=compare,
+    )
+    dom.start()
+    chunk_html = dom.render_system.html_render_roi.get(chunk_index, "")
+    typer.echo(chunk_html)
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,12 @@ dependencies = [
     "beautifulsoup4",
     "lxml",
     "treelib",
-    "parsel_text"
+    "parsel_text",
+    "typer"
 ]
+
+[project.scripts]
+betterhtmlchunking = "betterhtmlchunking.cli:app"
 
 [project.urls]
 repository = "https://github.com/carlosplanchon/betterhtmlchunking.git"


### PR DESCRIPTION
## Summary
- update README CLI example to show default 32768 max length

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m betterhtmlchunking.cli` *(fails: ModuleNotFoundError: No module named 'attrs')*

------
https://chatgpt.com/codex/tasks/task_e_683f697e4850832a811cfc1fa074c932