### PR TITLE
feat: add verbosity option to start

### DIFF
--- a/betterhtmlchunking/cli.py
+++ b/betterhtmlchunking/cli.py
@@ -1,4 +1,5 @@
 import sys
+
 import typer
 from .main import DomRepresentation, ReprLengthComparisionBy
 
@@ -32,7 +33,7 @@ def chunk(
         website_code=html_input,
         repr_length_compared_by=compare,
     )
-    dom.start()
+    dom.start(verbose=False)
     chunk_html = dom.render_system.html_render_roi.get(chunk_index, "")
     typer.echo(chunk_html)
 

--- a/betterhtmlchunking/main.py
+++ b/betterhtmlchunking/main.py
@@ -108,11 +108,23 @@ class DomRepresentation:
             tree_representation=self.tree_representation
         )
 
-    def start(self):
-        print("--- DOM REPRESENTATION ---")
-        print(" > Computing tree representation:")
+    def start(self, verbose: bool = False):
+        """Run the full chunking pipeline.
+
+        Parameters
+        ----------
+        verbose:
+            If ``True``, progress information is printed to stdout.
+            When ``False`` (the default) the method runs silently so that
+            callers such as the CLI can output only the chunk HTML.
+        """
+        if verbose:
+            print("--- DOM REPRESENTATION ---")
+            print(" > Computing tree representation:")
         self.compute_tree_representation()
-        print(" > Computing tree regions system:")
+        if verbose:
+            print(" > Computing tree regions system:")
         self.compute_tree_regions_system()
-        print(" > Computing render:")
+        if verbose:
+            print(" > Computing render:")
         self.compute_render_system()


### PR DESCRIPTION
## Summary
- control verbosity of `DomRepresentation.start` via a new `verbose` flag
- call start silently from CLI and ensure `sys` is imported

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae40926074832a9ca1e0ec6b5c022d