### PR TITLE
Ensure leftover ROI are retained

### DIFF
--- a/betterhtmlchunking/tree_regions_system.py
+++ b/betterhtmlchunking/tree_regions_system.py
@@ -115,6 +115,14 @@ class ROIMaker:
         while self.PARSING_STATE != ROIParsingState.EOF:
             self.step()
 
+        # If no region was finalized but some nodes were gathered, ensure
+        # this collected region is not lost.
+        if (
+            len(self.regions_of_interest_list) == 0
+            and self.actual_region_of_interest.pos_xpath_list != []
+        ):
+            self.regions_of_interest_list.append(self.actual_region_of_interest)
+
         node_is_roi: bool = False
         if len(self.children_tags) == 0:
             node_is_roi = True


### PR DESCRIPTION
## Summary
- Preserve gathered ROI when iteration finds none by appending it before final checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4ca30f34832a946685b2a134bd5e