### PR TITLE
Warn when leaf nodes exceed ROI length limit

### DIFF
--- a/betterhtmlchunking/tree_regions_system.py
+++ b/betterhtmlchunking/tree_regions_system.py
@@ -5,6 +5,7 @@ import attrs
 from attrs_strict import type_validator
 
 import queue
+import warnings
 
 import treelib
 
@@ -116,8 +117,22 @@ class ROIMaker:
             self.step()
 
         node_is_roi: bool = False
+        node_repr_length: Optional[int] = None
         if len(self.children_tags) == 0:
             node_is_roi = True
+            node = self.tree_representation.tree.get_node(
+                nid=self.node_xpath
+            )
+            node_repr_length = self.get_node_repr_length(node=node)
+            if node_repr_length > self.max_node_repr_length:
+                warnings.warn(
+                    (
+                        f"Leaf node '{self.node_xpath}' has length "
+                        f"{node_repr_length} which exceeds the maximum "
+                        f"allowed ({self.max_node_repr_length}). "
+                        "Consider splitting the text or increasing the limit."
+                    )
+                )
         elif len(self.regions_of_interest_list) == 1:
             roi = self.regions_of_interest_list[0]
             if len(roi.pos_xpath_list) == len(self.children_tags):
@@ -126,13 +141,11 @@ class ROIMaker:
         # Node itself is ROI.
         if node_is_roi is True:
             # print(f"> Node itself is ROI: {self.node_xpath}")
-            node: treelib.Node =\
-                self.tree_representation.tree.get_node(
+            if node_repr_length is None:
+                node: treelib.Node = self.tree_representation.tree.get_node(
                     nid=self.node_xpath
                 )
-
-            node_repr_length: int =\
-                self.get_node_repr_length(node=node)
+                node_repr_length = self.get_node_repr_length(node=node)
 
             # prettyprinter.cpprint(node_repr_length)
 


### PR DESCRIPTION
## Summary
- warn when a leaf node has text or HTML length beyond the ROI limit
- reuse computed node length when promoting node itself to ROI

## Testing
- `python -m py_compile betterhtmlchunking/tree_regions_system.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae4da07388832aa88e865293314e2f