### PR TITLE
Add ROI warning test for length limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ You can even combine the two techniques if you need both **structured extraction
 The package ships with a small command line interface built with [Typer](https://typer.tiangolo.com/). You can pipe HTML to the tool and obtain a specific chunk as HTML:
 
 ```bash
-cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 1 > chunk.html
+cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 > chunk.html
 ```
 
 By default the command reads from `stdin`, processes chunks up to a maximum length of 32,768 characters, and prints the HTML corresponding to chunk index `0` to `stdout`.

--- a/tests/test_roi_limits.py
+++ b/tests/test_roi_limits.py
@@ -1,0 +1,19 @@
+import pytest
+
+from betterhtmlchunking.main import DomRepresentation
+from betterhtmlchunking.tree_regions_system import ReprLengthComparisionBy
+
+
+def test_roi_warning_and_limits():
+    html = "<p>" + "a" * 25 + "</p>"
+    max_len = 10
+    dom = DomRepresentation(
+        MAX_NODE_REPR_LENGTH=max_len,
+        website_code=html,
+        repr_length_compared_by=ReprLengthComparisionBy.TEXT_LENGTH,
+    )
+    with pytest.warns(UserWarning):
+        dom.start()
+    roi = dom.tree_regions_system.sorted_roi_by_pos_xpath[0]
+    assert roi.node_is_roi is True
+    assert roi.repr_length > max_len


### PR DESCRIPTION
## Summary
- add test ensuring ROI warns when text length exceeds limit

## Testing
- `pytest tests/test_roi_limits.py -q` *(fails: ModuleNotFoundError: No module named 'betterhtmlchunking')*

------
https://chatgpt.com/codex/tasks/task_e_68ae4fdda840832a90d3c12526efc66e