### PR TITLE
Add root selection test without html tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ You can even combine the two techniques if you need both **structured extraction
 The package ships with a small command line interface built with [Typer](https://typer.tiangolo.com/). You can pipe HTML to the tool and obtain a specific chunk as HTML:
 
 ```bash
-cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 1 > chunk.html
+cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 > chunk.html
 ```
 
 By default the command reads from `stdin`, processes chunks up to a maximum length of 32,768 characters, and prints the HTML corresponding to chunk index `0` to `stdout`.

--- a/tests/test_root_selection.py
+++ b/tests/test_root_selection.py
@@ -1,0 +1,19 @@
+import betterhtmlchunking.tree_representation as tr
+from betterhtmlchunking.tree_regions_system import TreeRegionsSystem
+
+
+def test_root_selection_without_html_tag():
+    html = "<div><p>Hello World</p></div>"
+    dom_tree = tr.DOMTreeRepresentation(website_code=html)
+
+    trs = TreeRegionsSystem(
+        tree_representation=dom_tree,
+        max_node_repr_length=200,
+    )
+
+    assert trs.sorted_roi_by_pos_xpath, "ROI list should not be empty"
+
+    first_pos_xpath = dom_tree.pos_xpaths_list[0]
+    first_roi = trs.sorted_roi_by_pos_xpath[0]
+
+    assert first_roi.pos_xpath_list[0] == first_pos_xpath


### PR DESCRIPTION
## Summary
- add pytest for TreeRegionsSystem root selection when HTML lacks `<html>`

## Testing
- `pytest -q` *(fails: No module named 'betterhtmlchunking')*

------
https://chatgpt.com/codex/tasks/task_e_68ae4fdeb3dc832a8367f7ec7da3a6d7