### PR TITLE
Add CLI ROI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ You can even combine the two techniques if you need both **structured extraction
 The package ships with a small command line interface built with [Typer](https://typer.tiangolo.com/). You can pipe HTML to the tool and obtain a specific chunk as HTML:
 
 ```bash
-cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 1 > chunk.html
+cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 > chunk.html
 ```
 
 By default the command reads from `stdin`, processes chunks up to a maximum length of 32,768 characters, and prints the HTML corresponding to chunk index `0` to `stdout`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,35 @@
+import betterhtmlchunking.cli as cli
+from betterhtmlchunking.main import DomRepresentation, ReprLengthComparisionBy
+from typer.testing import CliRunner
+
+
+def test_chunk_html_stdout_contains_roi_and_stderr_empty():
+    html_input = "<html><body><p>first</p><p>second</p></body></html>"
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["chunk"], input=html_input)
+    dom = DomRepresentation(
+        MAX_NODE_REPR_LENGTH=32768,
+        website_code=html_input,
+        repr_length_compared_by=ReprLengthComparisionBy.HTML_LENGTH,
+    )
+    dom.start()
+    expected = dom.render_system.html_render_roi.get(0, "")
+    assert result.exit_code == 0
+    assert result.stdout == expected + "\n"
+    assert result.stderr == ""
+
+
+def test_chunk_text_stdout_contains_roi_and_stderr_empty():
+    html_input = "<html><body><p>first</p><p>second</p></body></html>"
+    runner = CliRunner()
+    result = runner.invoke(cli.app, ["chunk", "--text"], input=html_input)
+    dom = DomRepresentation(
+        MAX_NODE_REPR_LENGTH=32768,
+        website_code=html_input,
+        repr_length_compared_by=ReprLengthComparisionBy.TEXT_LENGTH,
+    )
+    dom.start()
+    expected = dom.render_system.text_render_roi.get(0, "")
+    assert result.exit_code == 0
+    assert result.stdout == expected + "\n"
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary
- add CLI tests verifying ROI output for HTML and text modes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'betterhtmlchunking')*

------
https://chatgpt.com/codex/tasks/task_e_68ae4fe075e0832abbe48c3ebd63c650