### PR TITLE
Add tests for utils, DOM paths, and HTML chunking

### DIFF
--- a/tests/test_chunking_pipeline.py
+++ b/tests/test_chunking_pipeline.py
@@ -1,0 +1,23 @@
+from betterhtmlchunking.main import DomRepresentation
+from betterhtmlchunking.tree_regions_system import ReprLengthComparisionBy
+
+
+def test_large_html_is_split_into_multiple_chunks():
+    html = (
+        "<html><body>"
+        + "".join(f"<p>{'x'*20}</p>" for _ in range(10))
+        + "</body></html>"
+    )
+    dom = DomRepresentation(
+        MAX_NODE_REPR_LENGTH=50,
+        website_code=html,
+        repr_length_compared_by=ReprLengthComparisionBy.TEXT_LENGTH,
+    )
+    dom.start()
+
+    chunks = dom.render_system.text_render_roi
+    assert len(chunks) > 1
+    combined_text = "".join(chunks.values()).replace("\n", "")
+    assert len(combined_text) == 200
+    for chunk in chunks.values():
+        assert len(chunk.replace("\n", "")) <= 50

--- a/tests/test_tree_representation.py
+++ b/tests/test_tree_representation.py
@@ -1,0 +1,11 @@
+import bs4
+
+from betterhtmlchunking.tree_representation import get_pos_xpath_from_bs4_elem
+
+
+def test_get_pos_xpath_from_bs4_elem_counts_siblings():
+    html = "<html><body><div></div><div></div></body></html>"
+    soup = bs4.BeautifulSoup(html, "html.parser")
+    divs = soup.find_all("div")
+    assert get_pos_xpath_from_bs4_elem(divs[0]) == "/html/body/div[1]"
+    assert get_pos_xpath_from_bs4_elem(divs[1]) == "/html/body/div[2]"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+import pytest
+
+from betterhtmlchunking.utils import wanted_xpath, remove_unwanted_tags
+from betterhtmlchunking.tree_representation import DOMTreeRepresentation
+
+
+def test_wanted_xpath_accepts_path_without_unwanted_tag():
+    assert wanted_xpath("/html/body/div", ["/script", "/style"]) is True
+
+
+def test_wanted_xpath_rejects_path_with_unwanted_tag():
+    assert wanted_xpath("/html/body/script", ["/script", "/style"]) is False
+
+
+def test_remove_unwanted_tags_prunes_tree():
+    html = (
+        "<html><body><p>keep</p>"
+        "<script>alert('x')</script>"
+        "<style>p{color:red}</style>"
+        "</body></html>"
+    )
+    tree = DOMTreeRepresentation(website_code=html)
+    remove_unwanted_tags(tree, ["/script", "/style"])
+    tree.recompute_representation()
+    assert "/html/body/p" in tree.pos_xpaths_list
+    assert all("/script" not in xp and "/style" not in xp for xp in tree.pos_xpaths_list)


### PR DESCRIPTION
## Summary
- Add unit tests for XPath filtering utilities
- Add test ensuring positional XPaths count repeated siblings correctly
- Add test verifying large HTML splits into multiple chunks respecting length limits

## Testing
- `pip install attrs attrs-strict beautifulsoup4 lxml treelib parsel-text typer` *(fails: Could not connect to proxy and find packages)*
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'attrs')*


------
https://chatgpt.com/codex/tasks/task_e_68ae584fdec0832a96654dd196dd3094