### PR TITLE
Fix unwanted tag filter logic

### DIFF
--- a/betterhtmlchunking/utils.py
+++ b/betterhtmlchunking/utils.py
@@ -9,8 +9,41 @@ def wanted_xpath(
     xpath: str,
     tag_list_to_filter_out: list[str]
         ) -> bool:
-    # Check if any of the unwanted tags are present in the given XPath
-    return not any(tag in xpath for tag in tag_list_to_filter_out)
+    """Check if a node should be kept based on its XPath.
+
+    The previous implementation relied on simple substring matching which
+    meant that filtering out ``"/head"`` would also remove nodes such as
+    ``"/header"``.  To avoid these partial matches we compare XPath segments
+    against the unwanted tags, ignoring positional indices and case.
+
+    Parameters
+    ----------
+    xpath:
+        The XPath of the node to evaluate.
+    tag_list_to_filter_out:
+        Tags or paths to exclude.  Each entry may contain multiple segments
+        (e.g. ``"/html/head"``).
+    """
+
+    def _split(xpath_to_split: str) -> list[str]:
+        """Return a list of lowercase tag names without positional indices."""
+        return [
+            segment.split("[")[0].lower()
+            for segment in xpath_to_split.strip("/").split("/")
+            if segment
+        ]
+
+    xpath_segments = _split(xpath)
+
+    for tag in tag_list_to_filter_out:
+        tag_segments = _split(tag)
+        tag_len = len(tag_segments)
+        # Slide over the xpath segments to look for an exact sequence match
+        for i in range(len(xpath_segments) - tag_len + 1):
+            if xpath_segments[i : i + tag_len] == tag_segments:
+                return False
+
+    return True
 
 
 def remove_unwanted_tags(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,3 +24,11 @@ def test_remove_unwanted_tags_prunes_tree():
     tree.recompute_representation()
     assert "/html/body/p" in tree.pos_xpaths_list
     assert all("/script" not in xp and "/style" not in xp for xp in tree.pos_xpaths_list)
+
+
+def test_wanted_xpath_does_not_match_partial_names():
+    assert wanted_xpath("/html/body/header", ["/head"]) is True
+
+
+def test_wanted_xpath_handles_indexed_nodes():
+    assert wanted_xpath("/html/body/script[1]", ["/script"]) is False


### PR DESCRIPTION
## Summary
- Avoid partial matches when filtering unwanted tags in XPaths
- Add tests for partial and indexed tag scenarios

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'attrs')*
- `pip install -q -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ae633ed6bc832ab5128884b01edc01