### PR TITLE
Duplicated /footer tag

### DIFF
--- a/betterhtmlchunking/main.py
+++ b/betterhtmlchunking/main.py
@@ -31,7 +31,6 @@ tag_list_to_filter_out: list[str] = [
     "/defs",
     "/g",
     "/header",
-    "/footer",
     "/script",
     "/style"
 ]


### PR DESCRIPTION
Such a small fix i decided to PR directly to main.

The /footer tag was duplicated in tag_list_to_filter_out.