### PR TITLE
Replace print with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 > chunk.h
 
 By default the command reads from `stdin`, processes chunks up to a maximum length of 32,768 characters, and prints the HTML corresponding to chunk index `0` to `stdout`.
 
+### Verbose mode
+
+You can enable progress logging with `--verbose`. Logs are written to `stderr` so they don’t interfere with chunk output:
+
+```bash
+cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 --verbose > chunk.html
+```
+
 ## License
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -193,6 +193,25 @@ You can enable progress logging with `--verbose`. Logs are written to `stderr` s
 cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 --verbose > chunk.html
 ```
 
+### Maximal Verbose Mode
+
+For a detailed inspection of the DOM, nodes, ROIs, and chunk lengths, use `--maximal-verbose`. This logs:
+
+* Total DOM nodes and their HTML/text lengths
+* Each ROI (region of interest) with constituent node XPaths and lengths
+* Final chunk HTML and text sizes
+
+```bash
+cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 --maximal-verbose > chunk.html 2> logs.txt
+```
+
+* `chunk.html` contains the selected chunk HTML.
+* `logs.txt` captures all detailed logging information.
+
+This mode is useful for debugging, testing, or analyzing how the document is split into chunks.
+
+---
+
 ## License
 
 MIT License

--- a/betterhtmlchunking/cli.py
+++ b/betterhtmlchunking/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
-
+import logging
 import typer
 from .main import DomRepresentation, ReprLengthComparisionBy
 
@@ -25,19 +25,41 @@ def chunk(
         False,
         "--text",
         help="Compare length using text instead of HTML",
-    )
-        ):
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Enable verbose logging output",
+    ),
+):
     """Read HTML from stdin and output the selected chunk as HTML."""
+
+    # --- Logging Config to stderr ---
+    logging.basicConfig(
+        level=logging.INFO if verbose else logging.WARNING,
+        format="%(message)s",
+        stream=sys.stderr,
+    )
+
     html_input = sys.stdin.read()
-    compare = ReprLengthComparisionBy.TEXT_LENGTH if by_text else ReprLengthComparisionBy.HTML_LENGTH
+    compare = (
+        ReprLengthComparisionBy.TEXT_LENGTH
+        if by_text
+        else ReprLengthComparisionBy.HTML_LENGTH
+    )
+
     dom = DomRepresentation(
         MAX_NODE_REPR_LENGTH=max_length,
         website_code=html_input,
         repr_length_compared_by=compare,
     )
-    dom.start(verbose=False)
+    dom.start(verbose=verbose)
+
+    # Chunk HTML always goes to stdout
     chunk_html = dom.render_system.html_render_roi.get(chunk_index, "")
     typer.echo(chunk_html)
+
 
 if __name__ == "__main__":
     app()

--- a/betterhtmlchunking/cli.py
+++ b/betterhtmlchunking/cli.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import sys
-import logging
 import typer
-from .main import DomRepresentation, ReprLengthComparisionBy
+from .main import DomRepresentation, ReprLengthComparisionBy, logger
+import logging
 
 app = typer.Typer(help="Chunk HTML documents from the command line")
 
@@ -32,15 +32,14 @@ def chunk(
         "-v",
         help="Enable verbose logging output",
     ),
+    maximal_verbose: bool = typer.Option(
+        False, "--maximal-verbose", help="Enable maximal verbose logging"
+    ),
 ):
     """Read HTML from stdin and output the selected chunk as HTML."""
 
-    # --- Logging Config to stderr ---
-    logging.basicConfig(
-        level=logging.INFO if verbose else logging.WARNING,
-        format="%(message)s",
-        stream=sys.stderr,
-    )
+    # Adjust logger level
+    logger.setLevel(logging.INFO if (verbose or maximal_verbose) else logging.WARNING)
 
     html_input = sys.stdin.read()
     compare = (
@@ -54,7 +53,7 @@ def chunk(
         website_code=html_input,
         repr_length_compared_by=compare,
     )
-    dom.start(verbose=verbose)
+    dom.start(verbose=verbose, maximal_verbose=maximal_verbose)
 
     # Chunk HTML always goes to stdout
     chunk_html = dom.render_system.html_render_roi.get(chunk_index, "")

--- a/betterhtmlchunking/main.py
+++ b/betterhtmlchunking/main.py
@@ -6,7 +6,6 @@ import logging
 from typing import Optional
 
 from attrs_strict import type_validator
-
 from betterhtmlchunking.utils import remove_unwanted_tags
 from betterhtmlchunking.tree_representation import DOMTreeRepresentation
 from betterhtmlchunking.tree_regions_system import (
@@ -15,9 +14,15 @@ from betterhtmlchunking.tree_regions_system import (
 )
 from betterhtmlchunking.render_system import RenderSystem
 
-
 # Module-level logger
 logger = logging.getLogger(__name__)
+logger.propagate = False  # Prevent double logging
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)  # default; CLI can override
 
 tag_list_to_filter_out: list[str] = [
     "/head",
@@ -35,25 +40,29 @@ tag_list_to_filter_out: list[str] = [
 
 @attrs.define()
 class DomRepresentation:
-    # Input:
+    # Input
     MAX_NODE_REPR_LENGTH: int = attrs.field(
         validator=type_validator()
     )
     website_code: str = attrs.field(
-        validator=type_validator(),
+        validator=type_validator(), 
         repr=False
     )
     repr_length_compared_by: ReprLengthComparisionBy = attrs.field(
         validator=type_validator()
     )
 
-    # Optional inputs:
+    # Optional inputs
     tag_list_to_filter_out: Optional[list[str]] = attrs.field(
-        validator=type_validator(), default=None
+        validator=type_validator(), 
+        default=None
     )
-    html_unescape: bool = attrs.field(validator=type_validator(), default=True)
+    html_unescape: bool = attrs.field(
+        validator=type_validator(), 
+        default=True
+    )
 
-    # Result:
+    # Result
     tree_representation: DOMTreeRepresentation = attrs.field(
         validator=type_validator(), init=False, repr=False
     )
@@ -67,13 +76,12 @@ class DomRepresentation:
     def __attrs_post_init__(self):
         if self.tag_list_to_filter_out is None:
             self.tag_list_to_filter_out = tag_list_to_filter_out
-
-        if self.html_unescape is True:
-            self.website_code: str = html.unescape(self.website_code)
+        if self.html_unescape:
+            self.website_code = html.unescape(self.website_code)
 
     def compute_tree_representation(self):
         self.tree_representation = DOMTreeRepresentation(
-            website_code=self.website_code,
+            website_code=self.website_code
         )
         self.tree_representation = remove_unwanted_tags(
             tree_representation=self.tree_representation,
@@ -94,25 +102,52 @@ class DomRepresentation:
             tree_representation=self.tree_representation,
         )
 
-    def start(self, verbose: bool = False):
-        """Run the full chunking pipeline.
+    def start(self, verbose: bool = False, maximal_verbose: bool = False):
+        """Run the full chunking pipeline with optional verbose logging.
 
         Parameters
         ----------
         verbose:
-            If ``True``, progress information is logged at INFO level.
-            When ``False`` (the default) the method runs silently so that
-            callers such as the CLI can output only the chunk HTML.
+            Logs high-level pipeline steps.
+        maximal_verbose:
+            Logs detailed DOM, node info, ROIs, and chunk info.
         """
-        if verbose:
+        if verbose or maximal_verbose:
             logger.info("--- DOM REPRESENTATION ---")
             logger.info(" > Computing tree representation:")
         self.compute_tree_representation()
 
-        if verbose:
+        if maximal_verbose:
+            all_nodes = self.tree_representation.tree.all_nodes()
+            logger.info(f"Total nodes in DOM tree: {len(all_nodes)}")
+            for node in all_nodes:
+                if node.data is not None:
+                    logger.info(
+                        f"Node XPath: {node.identifier}, "
+                        f"HTML length: {node.data.html_length}, "
+                        f"Text length: {node.data.text_length}"
+                    )
+
+        if verbose or maximal_verbose:
             logger.info(" > Computing tree regions system:")
         self.compute_tree_regions_system()
 
-        if verbose:
+        if maximal_verbose:
+            roi_count = len(self.tree_regions_system.sorted_roi_by_pos_xpath)
+            logger.info(f"Total ROIs (chunks): {roi_count}")
+            for idx in self.tree_regions_system.sorted_roi_by_pos_xpath:
+                roi = self.tree_regions_system.sorted_roi_by_pos_xpath[idx]
+                logger.info(
+                    f"ROI {idx}: HTML length {roi.repr_length}, Nodes XPaths: {roi.pos_xpath_list}"
+                )
+
+        if verbose or maximal_verbose:
             logger.info(" > Computing render:")
         self.compute_render_system()
+
+        if maximal_verbose:
+            for idx, html_chunk in self.render_system.html_render_roi.items():
+                text_chunk = self.render_system.text_render_roi.get(idx, "")
+                logger.info(
+                    f"Chunk {idx}: HTML {len(html_chunk)} chars, Text {len(text_chunk)} chars"
+                )


### PR DESCRIPTION
Replaced `print` statements with `logging.info` so progress messages go to **stderr**, keeping chunk output clean on **stdout**.

### **Changes**

* Added `logging` setup in CLI (`--verbose` enables INFO).
* Updated `DomRepresentation.start` to use logging.

### **Usage**

```bash
cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 > chunk.html        # quiet  
cat input.html | betterhtmlchunking --max-length 32768 --chunk-index 0 --verbose > chunk.html  # logs → stderr  
```